### PR TITLE
python_2_unicode_compatible removed from django 3.0

### DIFF
--- a/scheduler/__init__.py
+++ b/scheduler/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 default_app_config = 'scheduler.apps.SchedulerConfig'

--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Case, When, Value
 from django.templatetags.tz import utc
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
@@ -21,7 +20,6 @@ from model_utils.models import TimeStampedModel
 RQ_SCHEDULER_INTERVAL = getattr(settings, "DJANGO_RQ_SCHEDULER_INTERVAL", 60)
 
 
-@python_2_unicode_compatible
 class BaseJobArg(models.Model):
 
     ARG_TYPE = Choices(
@@ -101,7 +99,6 @@ class JobKwarg(BaseJobArg):
         return self.key, super(JobKwarg, self).value()
 
 
-@python_2_unicode_compatible
 class BaseJob(TimeStampedModel):
 
     name = models.CharField(_('name'), max_length=128, unique=True)


### PR DESCRIPTION
django.utils.encoding.python_2_unicode_compatible() - Alias of six.python_2_unicode_compatible() was removed with Django 3.0's release.